### PR TITLE
Add a delegateCall test regarding memory

### DIFF
--- a/test/TestDelegateCall.sol
+++ b/test/TestDelegateCall.sol
@@ -27,7 +27,7 @@ contract Caller {
         bytes32 ptr;
         assembly{
             ptr := mload(0x40)
-            //We write a slot in the memory before the call 
+            // We write a slot in the memory before the call.
             mstore(ptr, 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
             mstore(0x40, add(ptr, 0x20))
         }
@@ -36,11 +36,11 @@ contract Caller {
         
         assembly{
             ptr := mload(0x40)
-            //We write a slot in the memory after the call
+            // We write a slot in the memory after the call.
             mstore(ptr, 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
             mstore(0x40, add(ptr, 0x20))
         }
-        //We store the memory in allMem
+        // We store the memory in allMem.
         assembly{
             ptr := mload(0x40)
             allMem := 0x00
@@ -175,8 +175,8 @@ contract TestDelegateCall is Test {
     }
 
     function testMemoryUncorruptedWithRef() public{
-        //This test makes sure that the delegateCall function of our library acts on the memory in the exact same way 
-        //as a targetBehaviour function corresponding to the desired behavior.
+        // This test makes sure that the delegateCall function of our library acts on the memory in the exact same way 
+        // as a targetBehaviour function corresponding to the desired behavior.
         bytes memory memoryReturned;
         bytes32 pointerReturned;
         bytes memory memoryReturnedRef;

--- a/test/TestDelegateCall.sol
+++ b/test/TestDelegateCall.sol
@@ -174,7 +174,7 @@ contract TestDelegateCall is Test {
         caller.delegateCall(Called.revertWithCustomError.selector);
     }
 
-function testMemoryUncorruptedWithRef() public{
+    function testMemoryUncorruptedWithRef() public{
         //This test makes sure that the delegateCall function of our library acts on the memory in the exact same way 
         //as a targetBehaviour function corresponding to the desired behavior.
         bytes memory memoryReturned;

--- a/test/TestDelegateCall.sol
+++ b/test/TestDelegateCall.sol
@@ -20,11 +20,40 @@ contract Caller {
         bytes memory data = called.functionDelegateCall(abi.encodeWithSelector(_selector, ""));
         return abi.decode(data, (uint256));
     }
+
+
+    function delegateCallAndReturnMemoryAndPointer(bytes4 _selector) external returns (bytes memory, bytes32) {
+        bytes memory allMem;
+        bytes32 ptr;
+        assembly{
+            ptr := mload(0x40)
+            //We write a slot in the memory before the call 
+            mstore(ptr, 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+            mstore(0x40, add(ptr, 0x20))
+        }
+
+        called.functionDelegateCall(abi.encodeWithSelector(_selector, ""));
+        
+        assembly{
+            ptr := mload(0x40)
+            //We write a slot in the memory after the call
+            mstore(ptr, 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+            mstore(0x40, add(ptr, 0x20))
+        }
+        //We store the memory in allMem
+        assembly{
+            ptr := mload(0x40)
+            allMem := 0x00
+            mstore(allMem, mload(0x40))
+        }
+
+        return (allMem, ptr);
+    }
 }
 
 contract CallerRef {
     using Address for address;
-
+    error LowLevelDelegateCallFailed();
     address public immutable called;
     uint256 public x = 2;
 
@@ -36,6 +65,47 @@ contract CallerRef {
         bytes memory data = called.functionDelegateCall(abi.encodeWithSelector(_selector, ""));
         return abi.decode(data, (uint256));
     }
+
+    function targetDelegateCallBehaviour(address _target, bytes memory _data) internal returns (bytes memory) {
+        (bool success, bytes memory returndata) = _target.delegatecall(_data);
+        if (success) return returndata;
+        else {
+            // Look for revert reason and bubble it up if present.
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly.
+                assembly {
+                    revert(add(32, returndata), mload(returndata))
+                }
+            } else revert LowLevelDelegateCallFailed();
+        }
+    }
+    
+    function targetDelegateCallBehaviourAndReturnMemoryAndPointer(bytes4 _selector) external returns (bytes memory, bytes32) {
+        bytes memory allMem;
+        bytes32 ptr;
+        assembly{
+            ptr := mload(0x40)
+            mstore(ptr, 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+            mstore(0x40, add(ptr, 0x20))
+        }
+
+        targetDelegateCallBehaviour(address(called),abi.encodeWithSelector(_selector, ""));
+        
+        assembly{
+            ptr := mload(0x40)
+            mstore(ptr, 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+            mstore(0x40, add(ptr, 0x20))
+        }
+
+        assembly{
+            ptr := mload(0x40)
+            allMem := 0x00
+            mstore(allMem, mload(0x40))
+        }
+
+        return (allMem, ptr);
+    }
+
 }
 
 contract Called {
@@ -45,6 +115,18 @@ contract Called {
 
     function number() external view returns (uint256) {
         return x;
+    }
+
+    function returnBytes32() external pure returns (bytes32){
+        return "33333333333333333333333333333333";
+    }
+
+    function return40Bytes() external pure returns (bytes memory) {
+        return "3333333333333333333333333333333333333333";
+    }
+
+    function return32Bytes() external pure returns (bytes memory) {
+        return "33333333333333333333333333333333";
     }
 
     function revertWithoutError() external pure {
@@ -90,6 +172,35 @@ contract TestDelegateCall is Test {
     function testRevertWithCustomError() public {
         vm.expectRevert(abi.encodeWithSelector(Called.DelegateCallError.selector));
         caller.delegateCall(Called.revertWithCustomError.selector);
+    }
+
+function testMemoryUncorruptedWithRef() public{
+        //This test makes sure that the delegateCall function of our library acts on the memory in the exact same way 
+        //as a targetBehaviour function corresponding to the desired behavior.
+        bytes memory memoryReturned;
+        bytes32 pointerReturned;
+        bytes memory memoryReturnedRef;
+        bytes32 pointerReturnedRef;
+
+        (memoryReturned, pointerReturned) = caller.delegateCallAndReturnMemoryAndPointer(Called.number.selector);
+        (memoryReturnedRef, pointerReturnedRef) = callerRef.targetDelegateCallBehaviourAndReturnMemoryAndPointer(Called.number.selector);
+        assert(keccak256(memoryReturned) == keccak256(memoryReturnedRef));
+        assert(pointerReturned == pointerReturnedRef);
+
+        (memoryReturned, pointerReturned) = caller.delegateCallAndReturnMemoryAndPointer(Called.return40Bytes.selector);
+        (memoryReturnedRef, pointerReturnedRef) = callerRef.targetDelegateCallBehaviourAndReturnMemoryAndPointer(Called.return40Bytes.selector);
+        assert(keccak256(memoryReturned) == keccak256(memoryReturnedRef));
+        assert(pointerReturned == pointerReturnedRef);
+
+        (memoryReturned, pointerReturned) = caller.delegateCallAndReturnMemoryAndPointer(Called.return32Bytes.selector);
+        (memoryReturnedRef, pointerReturnedRef) = callerRef.targetDelegateCallBehaviourAndReturnMemoryAndPointer(Called.return32Bytes.selector);
+        assert(keccak256(memoryReturned) == keccak256(memoryReturnedRef));
+        assert(pointerReturned == pointerReturnedRef);
+        
+        (memoryReturned, pointerReturned) = caller.delegateCallAndReturnMemoryAndPointer(Called.returnBytes32.selector);
+        (memoryReturnedRef, pointerReturnedRef) = callerRef.targetDelegateCallBehaviourAndReturnMemoryAndPointer(Called.returnBytes32.selector);
+        assert(keccak256(memoryReturned) == keccak256(memoryReturnedRef));
+        assert(pointerReturned == pointerReturnedRef);
     }
 
     /// GAS COMPARISONS ///


### PR DESCRIPTION
This test asserts that the delegateCall function of the delegateCall library leaves the memory in the same state as a the targetDelegateCallBehaviour function - which was the first implementation of the delegateCall library before being optimized in yul. This test compares the free memory pointer value and the full memory state using both functions. 

The idea behind targetDelegateCallBehaviourAndReturnMemoryAndPointer is to write in the memory before and after the delegateCall to not be in a trivial state with only 0's in memory. We test the memory on various data types returned by the delegateCall. 

Note: it is possible to make a full working implementation having this test failing (like having the free mem pointer further than ref implem) but is I believe not safe to do.