### PR TITLE
Optimized min-max-zeroFloorSub functions

### DIFF
--- a/src/math/Math.sol
+++ b/src/math/Math.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.0;
 library Math {
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
         assembly {
-            z := add(mul(x, lt(x,y)),mul(y, iszero(lt(x,y))))
+            z := add(mul(x, lt(x, y)), mul(y, iszero(lt(x, y))))
         }
     }
 
     function max(uint256 x, uint256 y) internal pure returns (uint256 z) {
         assembly {
-            z := add(mul(x, gt(x,y)), mul(y, iszero(gt(x,y))))
+            z := add(mul(x, gt(x, y)), mul(y, iszero(gt(x, y))))
         }
     }
 

--- a/src/math/Math.sol
+++ b/src/math/Math.sol
@@ -4,19 +4,13 @@ pragma solidity ^0.8.0;
 library Math {
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
         assembly {
-            z := x
-            if lt(y, x) {
-                z := y
-            }
+            z := add(mul(x, lt(x,y)),mul(y, iszero(lt(x,y))))
         }
     }
 
     function max(uint256 x, uint256 y) internal pure returns (uint256 z) {
         assembly {
-            z := x
-            if gt(y, x) {
-                z := y
-            }
+            z := add(mul(x, gt(x,y)), mul(y, iszero(gt(x,y))))
         }
     }
 

--- a/src/math/Math.sol
+++ b/src/math/Math.sol
@@ -17,9 +17,7 @@ library Math {
     /// @dev Returns max(x - y, 0).
     function zeroFloorSub(uint256 x, uint256 y) internal pure returns (uint256 z) {
         assembly {
-            if gt(x, y) {
-                z := sub(x, y)
-            }
+            z := mul(gt(x, y), sub(x, y))
         }
     }
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/75758585/182022141-80637f11-70cb-4921-8840-4afdcbc06c3d.png)
After:
![image](https://user-images.githubusercontent.com/75758585/182022076-7b6c0a68-24d7-47e9-ad9a-83697ffb4142.png)
Same savings for zerFloorSub