### PR TITLE
Perf percentage math

### DIFF
--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -66,10 +66,9 @@ library PercentageMath {
     /// @param percentage The percentage of the value to multiply.
     /// @return y The result of the multiplication.
     function percentMul(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
-        // Let percentage > 0
-        // Overflow if x * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
-        // <=> x * percentage > type(uint256).max - HALF_PERCENTAGE_FACTOR
-        // <=> x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / percentage
+        // Should revert if
+        // x * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
+        // <=> percentage > 0 and x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / percentage
         assembly {
             if mul(percentage, gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, percentage))) {
                 revert(0, 0)
@@ -84,12 +83,13 @@ library PercentageMath {
     /// @param percentage The percentage of the value to divide.
     /// @return y The result of the division.
     function percentDiv(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
-        // let percentage > 0
-        // Overflow if x * PERCENTAGE_FACTOR + halfPercentage > type(uint256).max
-        // <=> x * PERCENTAGE_FACTOR > type(uint256).max - halfPercentage
-        // <=> x > type(uint256).max - halfPercentage / PERCENTAGE_FACTOR
+        // Should revert if
+        // percentage == 0
+        // or x * PERCENTAGE_FACTOR + percentage / 2 > type(uint256).max
+        // <=> percentage == 0
+        // or x > (type(uint256).max - percentage / 2) / PERCENTAGE_FACTOR
         assembly {
-            y := div(percentage, 2) // Temporary assignement to save gas.
+            y := div(percentage, 2) // Temporary assignment to save gas.
 
             if iszero(mul(percentage, iszero(gt(x, div(sub(MAX_UINT256, y), PERCENTAGE_FACTOR))))) {
                 revert(0, 0)

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -53,7 +53,7 @@ library PercentageMath {
         assembly {
             y := sub(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.
 
-            if or(gt(percentage, PERCENTAGE_FACTOR), and(y, gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, y)))) {
+            if or(gt(percentage, PERCENTAGE_FACTOR), mul(y, gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, y)))) {
                 revert(0, 0)
             }
 

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -25,11 +25,12 @@ library PercentageMath {
         // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR or x * (PERCENTAGE_FACTOR + percentage) > type(uint256).max - HALF_PERCENTAGE_FACTOR
         // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR or x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR + percentage)
         assembly {
-            if mul(add(percentage, PERCENTAGE_FACTOR), or(gt(percentage, sub(MAX_UINT256, PERCENTAGE_FACTOR)), gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, add(percentage, PERCENTAGE_FACTOR))))) {
+            y := add(percentage, PERCENTAGE_FACTOR)
+            if mul(y, or(gt(percentage, sub(MAX_UINT256, PERCENTAGE_FACTOR)), gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, y)))) {
                 revert(0, 0)
             }
 
-            y := div(add(mul(x, add(percentage, PERCENTAGE_FACTOR)), HALF_PERCENTAGE_FACTOR), PERCENTAGE_FACTOR)
+            y := div(add(mul(x, y), HALF_PERCENTAGE_FACTOR), PERCENTAGE_FACTOR)
         }
     }
 

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -22,9 +22,9 @@ library PercentageMath {
     function percentAdd(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
         // Must revert if
         // PERCENTAGE_FACTOR + percentage > type(uint256).max
-        // or x * (PERCENTAGE_FACTOR + percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
+        //     or x * (PERCENTAGE_FACTOR + percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
         // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR
-        // or x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR + percentage)
+        //     or x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR + percentage)
         // Note: PERCENTAGE_FACTOR + percentage >= PERCENTAGE_FACTOR > 0
         assembly {
             y := add(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.
@@ -47,9 +47,9 @@ library PercentageMath {
     function percentSub(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
         // Must revert if
         // percentage > PERCENTAGE_FACTOR
-        // or x * (PERCENTAGE_FACTOR - percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
+        //     or x * (PERCENTAGE_FACTOR - percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
         // <=> percentage > PERCENTAGE_FACTOR
-        // or ((PERCENTAGE_FACTOR - percentage) > 0 and x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage))
+        //     or ((PERCENTAGE_FACTOR - percentage) > 0 and x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage))
         assembly {
             y := sub(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.
 
@@ -85,9 +85,9 @@ library PercentageMath {
     function percentDiv(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
         // Must revert if
         // percentage == 0
-        // or x * PERCENTAGE_FACTOR + percentage / 2 > type(uint256).max
+        //     or x * PERCENTAGE_FACTOR + percentage / 2 > type(uint256).max
         // <=> percentage == 0
-        // or x > (type(uint256).max - percentage / 2) / PERCENTAGE_FACTOR
+        //     or x > (type(uint256).max - percentage / 2) / PERCENTAGE_FACTOR
         assembly {
             y := div(percentage, 2) // Temporary assignment to save gas.
 
@@ -110,16 +110,17 @@ library PercentageMath {
         uint256 percentage
     ) internal pure returns (uint256 z) {
         // Must revert if
-        // percentage > PERCENTAGE_FACTOR
-        // or
-        // x1 = x * (PERCENTAGE_FACTOR - percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
-        // <=> (PERCENTAGE_FACTOR - percentage) > 0 and x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage)
-        // or
-        // x2 = y * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
-        // <=> y * percentage > type(uint256).max - HALF_PERCENTAGE_FACTOR
-        // <=> percentage > 0 and y > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / percentage
+        //     percentage > PERCENTAGE_FACTOR
+        // or if
+        //     x1 = x * (PERCENTAGE_FACTOR - percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
+        //     <=> (PERCENTAGE_FACTOR - percentage) > 0 and x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage)
+        // or if
+        //     x2 = y * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
+        //     <=> y * percentage > type(uint256).max - HALF_PERCENTAGE_FACTOR
+        //     <=> percentage > 0 and y > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / percentage
         //
-        // Note: x1 / PERCENTAGE_FACTOR + x2 / PERCENTAGE_FACTOR < max(x,y) <= type(uint256).max
+        // Note: x1 / PERCENTAGE_FACTOR + x2 / PERCENTAGE_FACTOR <= x * (1 - percentage) + 1 + y * percentage + 1
+        // <= max(x, y) + 2 <= type(uint256).max - HALF_PERCENTAGE_FACTOR + 2 <= type(uint256).max
         assembly {
             z := sub(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.
 

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -25,7 +25,7 @@ library PercentageMath {
         // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR or x * (PERCENTAGE_FACTOR + percentage) > type(uint256).max - HALF_PERCENTAGE_FACTOR
         // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR or x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR + percentage)
         assembly {
-            if mul(percentage, or(gt(percentage, sub(MAX_UINT256, PERCENTAGE_FACTOR)), gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, percentage)))) {
+            if mul(add(percentage, PERCENTAGE_FACTOR), or(gt(percentage, sub(MAX_UINT256, PERCENTAGE_FACTOR)), gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, add(percentage, PERCENTAGE_FACTOR))))) {
                 revert(0, 0)
             }
 

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -18,9 +18,19 @@ library PercentageMath {
     /// @notice Executes a percentage addition.
     /// @param x The value of which the percentage needs to be added.
     /// @param percentage The percentage of the value to be added.
-    /// @return The result of the addition.
-    function percentAdd(uint256 x, uint256 percentage) internal pure returns (uint256) {
-        return percentMul(x, PERCENTAGE_FACTOR + percentage);
+    /// @return y The result of the addition.
+    function percentAdd(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
+        // Let percentage > 0
+        // Overflow if PERCENTAGE_FACTOR + percentage > type(uint256).max or x * (PERCENTAGE_FACTOR + percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
+        // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR or x * (PERCENTAGE_FACTOR + percentage) > type(uint256).max - HALF_PERCENTAGE_FACTOR
+        // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR or x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR + percentage)
+        assembly {
+            if mul(percentage, or(gt(percentage, sub(MAX_UINT256, PERCENTAGE_FACTOR)), gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, percentage)))) {
+                revert(0, 0)
+            }
+
+            y := div(add(mul(x, add(percentage, PERCENTAGE_FACTOR)), HALF_PERCENTAGE_FACTOR), PERCENTAGE_FACTOR)
+        }
     }
 
     /// @notice Executes a percentage subtraction.

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -112,12 +112,9 @@ library PercentageMath {
         // Must revert if
         //     percentage > PERCENTAGE_FACTOR
         // or if
-        //     x * (PERCENTAGE_FACTOR - percentage) > type(uint256).max
-        //     <=> PERCENTAGE_FACTOR - percentage > 0 and x > type(uint256).max / (PERCENTAGE_FACTOR - percentage)
-        // or if
         //     y * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
         //     <=> percentage > 0 and y > (type(uint256).max - percentage) / percentage
-        // or if (assuming that the 3 previous conditions are false)
+        // or if
         //     x * (PERCENTAGE_FACTOR - percentage) + y * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
         //     <=> x > type(uint256).max - y * percentage - HALF_PERCENTAGE_FACTOR / (PERCENTAGE_FACTOR - percentage)
         assembly {
@@ -125,11 +122,8 @@ library PercentageMath {
             if or(
                 gt(percentage, PERCENTAGE_FACTOR),
                 or(
-                    or(
-                        mul(percentage, gt(y, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, percentage))),
-                        mul(z, gt(x, div(MAX_UINT256, z)))
-                    ),
-                    gt(mul(x, z), sub(sub(MAX_UINT256, mul(y, percentage)), HALF_PERCENTAGE_FACTOR))
+                    mul(percentage, gt(y, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, percentage))),
+                    mul(z, gt(x, div(sub(sub(MAX_UINT256, mul(y, percentage)), HALF_PERCENTAGE_FACTOR), z)))
                 )
             ) {
                 revert(0, 0)

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -25,7 +25,7 @@ library PercentageMath {
         // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR or x * (PERCENTAGE_FACTOR + percentage) > type(uint256).max - HALF_PERCENTAGE_FACTOR
         // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR or x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR + percentage)
         assembly {
-            y := add(percentage, PERCENTAGE_FACTOR)
+            y := add(percentage, PERCENTAGE_FACTOR) // Temporary assīgnement to save gas.
 
             if mul(y, or(gt(percentage, sub(MAX_UINT256, PERCENTAGE_FACTOR)), gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, y)))) {
                 revert(0, 0)
@@ -46,7 +46,7 @@ library PercentageMath {
         // <=> x * (PERCENTAGE_FACTOR - percentage) > type(uint256).max - HALF_PERCENTAGE_FACTOR
         // <=> x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage)
         assembly {
-            y := sub(PERCENTAGE_FACTOR, percentage)
+            y := sub(PERCENTAGE_FACTOR, percentage) // Temporary assīgnement to save gas.
 
             if mul(y, or(gt(percentage, PERCENTAGE_FACTOR), gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, y)))) {
                 revert(0, 0)
@@ -84,7 +84,8 @@ library PercentageMath {
         // <=> x * PERCENTAGE_FACTOR > type(uint256).max - halfPercentage
         // <=> x > type(uint256).max - halfPercentage / PERCENTAGE_FACTOR
         assembly {
-            y := div(percentage, 2)
+            y := div(percentage, 2) // Temporary assīgnement to save gas.
+
             if iszero(mul(percentage, iszero(gt(x, div(sub(MAX_UINT256, y), PERCENTAGE_FACTOR))))) {
                 revert(0, 0)
             }

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -25,7 +25,7 @@ library PercentageMath {
         // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR or x * (PERCENTAGE_FACTOR + percentage) > type(uint256).max - HALF_PERCENTAGE_FACTOR
         // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR or x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR + percentage)
         assembly {
-            y := add(percentage, PERCENTAGE_FACTOR) // Temporary assīgnement to save gas.
+            y := add(percentage, PERCENTAGE_FACTOR) // Temporary assignement to save gas.
 
             if mul(
                 y,
@@ -52,7 +52,7 @@ library PercentageMath {
         // <=> x * (PERCENTAGE_FACTOR - percentage) > type(uint256).max - HALF_PERCENTAGE_FACTOR
         // <=> x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage)
         assembly {
-            y := sub(PERCENTAGE_FACTOR, percentage) // Temporary assīgnement to save gas.
+            y := sub(PERCENTAGE_FACTOR, percentage) // Temporary assignement to save gas.
 
             if mul(y, or(gt(percentage, PERCENTAGE_FACTOR), gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, y)))) {
                 revert(0, 0)
@@ -90,7 +90,7 @@ library PercentageMath {
         // <=> x * PERCENTAGE_FACTOR > type(uint256).max - halfPercentage
         // <=> x > type(uint256).max - halfPercentage / PERCENTAGE_FACTOR
         assembly {
-            y := div(percentage, 2) // Temporary assīgnement to save gas.
+            y := div(percentage, 2) // Temporary assignement to save gas.
 
             if iszero(mul(percentage, iszero(gt(x, div(sub(MAX_UINT256, y), PERCENTAGE_FACTOR))))) {
                 revert(0, 0)

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -20,7 +20,7 @@ library PercentageMath {
     /// @param percentage The percentage of the value to add.
     /// @return y The result of the addition.
     function percentAdd(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
-        // Should revert if
+        // Must revert if
         // PERCENTAGE_FACTOR + percentage > type(uint256).max
         // or x * (PERCENTAGE_FACTOR + percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
         // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR
@@ -45,7 +45,7 @@ library PercentageMath {
     /// @param percentage The percentage of the value to subtract.
     /// @return y The result of the subtraction.
     function percentSub(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
-        // Should revert if
+        // Must revert if
         // percentage > PERCENTAGE_FACTOR
         // or x * (PERCENTAGE_FACTOR - percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
         // <=> percentage > PERCENTAGE_FACTOR
@@ -66,7 +66,7 @@ library PercentageMath {
     /// @param percentage The percentage of the value to multiply.
     /// @return y The result of the multiplication.
     function percentMul(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
-        // Should revert if
+        // Must revert if
         // x * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
         // <=> percentage > 0 and x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / percentage
         assembly {
@@ -83,7 +83,7 @@ library PercentageMath {
     /// @param percentage The percentage of the value to divide.
     /// @return y The result of the division.
     function percentDiv(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
-        // Should revert if
+        // Must revert if
         // percentage == 0
         // or x * PERCENTAGE_FACTOR + percentage / 2 > type(uint256).max
         // <=> percentage == 0
@@ -109,7 +109,7 @@ library PercentageMath {
         uint256 y,
         uint256 percentage
     ) internal pure returns (uint256 z) {
-        // Should revert if
+        // Must revert if
         // percentage > PERCENTAGE_FACTOR
         // or
         // x1 = x * (PERCENTAGE_FACTOR - percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -116,14 +116,14 @@ library PercentageMath {
         //     <=> percentage > 0 and y > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / percentage
         // or if
         //     x * (PERCENTAGE_FACTOR - percentage) + y * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
-        //     <=> (PERCENTAGE_FACTOR - percentage) > 0 and x > (type(uint256).max - y * percentage - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage)
+        //     <=> (PERCENTAGE_FACTOR - percentage) > 0 and x > (type(uint256).max - HALF_PERCENTAGE_FACTOR - y * percentage) / (PERCENTAGE_FACTOR - percentage)
         assembly {
             z := sub(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.
             if or(
                 gt(percentage, PERCENTAGE_FACTOR),
                 or(
                     mul(percentage, gt(y, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, percentage))),
-                    mul(z, gt(x, div(sub(sub(MAX_UINT256, mul(y, percentage)), HALF_PERCENTAGE_FACTOR), z)))
+                    mul(z, gt(x, div(sub(MAX_UINT256_MINUS_HALF_PERCENTAGE, mul(y, percentage)), z)))
                 )
             ) {
                 revert(0, 0)

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -45,15 +45,15 @@ library PercentageMath {
     /// @param percentage The percentage of the value to subtract.
     /// @return y The result of the subtraction.
     function percentSub(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
-        // Let percentage > 0
-        // Underflow if percentage > PERCENTAGE_FACTOR
-        // Overflow if x * (PERCENTAGE_FACTOR - percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
-        // <=> x * (PERCENTAGE_FACTOR - percentage) > type(uint256).max - HALF_PERCENTAGE_FACTOR
-        // <=> x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage)
+        // Should revert if
+        // percentage > PERCENTAGE_FACTOR
+        // or x * (PERCENTAGE_FACTOR - percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
+        // <=> percentage > PERCENTAGE_FACTOR
+        // or ((PERCENTAGE_FACTOR - percentage) > 0 and x > type(uint256).max - HALF_PERCENTAGE_FACTOR / (PERCENTAGE_FACTOR - percentage))
         assembly {
-            y := sub(PERCENTAGE_FACTOR, percentage) // Temporary assignement to save gas.
+            y := sub(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.
 
-            if mul(y, or(gt(percentage, PERCENTAGE_FACTOR), gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, y)))) {
+            if or(gt(percentage, PERCENTAGE_FACTOR), and(y, gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, y)))) {
                 revert(0, 0)
             }
 

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -20,19 +20,18 @@ library PercentageMath {
     /// @param percentage The percentage of the value to add.
     /// @return y The result of the addition.
     function percentAdd(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
-        // Let percentage > 0
-        // Overflow if PERCENTAGE_FACTOR + percentage > type(uint256).max or x * (PERCENTAGE_FACTOR + percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
-        // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR or x * (PERCENTAGE_FACTOR + percentage) > type(uint256).max - HALF_PERCENTAGE_FACTOR
-        // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR or x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR + percentage)
+        // Should revert if
+        // PERCENTAGE_FACTOR + percentage > type(uint256).max
+        // or x * (PERCENTAGE_FACTOR + percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
+        // <=> percentage > type(uint256).max - PERCENTAGE_FACTOR
+        // or x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR + percentage)
+        // Note: PERCENTAGE_FACTOR + percentage >= PERCENTAGE_FACTOR > 0
         assembly {
-            y := add(percentage, PERCENTAGE_FACTOR) // Temporary assignement to save gas.
+            y := add(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.
 
-            if mul(
-                y,
-                or(
-                    gt(percentage, sub(MAX_UINT256, PERCENTAGE_FACTOR)),
-                    gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, y))
-                )
+            if or(
+                gt(percentage, sub(MAX_UINT256, PERCENTAGE_FACTOR)),
+                gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, y))
             ) {
                 revert(0, 0)
             }

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -113,10 +113,10 @@ library PercentageMath {
         //     percentage > PERCENTAGE_FACTOR
         // or if
         //     y * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
-        //     <=> percentage > 0 and y > (type(uint256).max - percentage) / percentage
+        //     <=> percentage > 0 and y > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / percentage
         // or if
         //     x * (PERCENTAGE_FACTOR - percentage) + y * percentage + HALF_PERCENTAGE_FACTOR > type(uint256).max
-        //     <=> x > type(uint256).max - y * percentage - HALF_PERCENTAGE_FACTOR / (PERCENTAGE_FACTOR - percentage)
+        //     <=> (PERCENTAGE_FACTOR - percentage) > 0 and x > (type(uint256).max - y * percentage - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage)
         assembly {
             z := sub(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.
             if or(

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -8,16 +8,16 @@ pragma solidity ^0.8.0;
 library PercentageMath {
     ///	CONSTANTS ///
 
-    uint256 internal constant PERCENTAGE_FACTOR = 1e4;
-    uint256 internal constant HALF_PERCENTAGE_FACTOR = 0.5e4;
+    uint256 internal constant PERCENTAGE_FACTOR = 1e4; // 100.00%
+    uint256 internal constant HALF_PERCENTAGE_FACTOR = 0.5e4; // 50.00%
     uint256 internal constant MAX_UINT256 = 2**256 - 1;
     uint256 internal constant MAX_UINT256_MINUS_HALF_PERCENTAGE = 2**256 - 1 - 0.5e4;
 
     /// INTERNAL ///
 
-    /// @notice Executes a percentage addition.
-    /// @param x The value of which the percentage needs to be added.
-    /// @param percentage The percentage of the value to be added.
+    /// @notice Executes a percentage addition (x * (1 + p)), rounded up.
+    /// @param x The value to which to add the percentage.
+    /// @param percentage The percentage of the value to add.
     /// @return y The result of the addition.
     function percentAdd(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
         // Let percentage > 0
@@ -41,9 +41,9 @@ library PercentageMath {
         }
     }
 
-    /// @notice Executes a percentage subtraction.
-    /// @param x The value of which the percentage needs to be subtracted.
-    /// @param percentage The percentage of the value to be subtracted.
+    /// @notice Executes a percentage subtraction (x * (1 - p)), rounded up.
+    /// @param x The value to which to subtract the percentage.
+    /// @param percentage The percentage of the value to subtract.
     /// @return y The result of the subtraction.
     function percentSub(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
         // Let percentage > 0
@@ -62,9 +62,9 @@ library PercentageMath {
         }
     }
 
-    /// @notice Executes a percentage multiplication.
-    /// @param x The value of which the percentage needs to be calculated.
-    /// @param percentage The percentage of the value to be calculated.
+    /// @notice Executes a percentage multiplication (x * p), rounded up.
+    /// @param x The value to multiply by the percentage.
+    /// @param percentage The percentage of the value to multiply.
     /// @return y The result of the multiplication.
     function percentMul(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
         // Let percentage > 0
@@ -80,9 +80,9 @@ library PercentageMath {
         }
     }
 
-    /// @notice Executes a percentage division.
-    /// @param x The value of which the percentage needs to be calculated.
-    /// @param percentage The percentage of the value to be calculated.
+    /// @notice Executes a percentage division (x / p), rounded up.
+    /// @param x The value to divide by the percentage.
+    /// @param percentage The percentage of the value to divide.
     /// @return y The result of the division.
     function percentDiv(uint256 x, uint256 percentage) internal pure returns (uint256 y) {
         // let percentage > 0
@@ -100,11 +100,11 @@ library PercentageMath {
         }
     }
 
-    /// @notice Executes a weighted average, given an interval [x, y] and a percent p: x * (1 - p) + y * p
-    /// @param x The value at the start of the interval (included).
-    /// @param y The value at the end of the interval (included).
-    /// @param percentage The percentage of the interval to be calculated.
-    /// @return z The average of x and y, weighted by percentage.
+    /// @notice Executes a weighted average (x * (1 - p) + y * p), rounded up.
+    /// @param x The first value, with a weight of 1 - percentage.
+    /// @param y The second value, with a weight of percentage.
+    /// @param percentage The weight of y, and complement of the weight of x.
+    /// @return z The result of the weighted average.
     function weightedAvg(
         uint256 x,
         uint256 y,

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -119,7 +119,7 @@ library PercentageMath {
         //     <=> y * percentage > type(uint256).max - HALF_PERCENTAGE_FACTOR
         //     <=> percentage > 0 and y > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / percentage
         //
-        // Note: x1 / PERCENTAGE_FACTOR + x2 / PERCENTAGE_FACTOR <= x * (1 - percentage) + 1 + y * percentage + 1
+        // Note: x1 / PERCENTAGE_FACTOR + x2 / PERCENTAGE_FACTOR <= x * (1 - p) + 1 + y * p + 1 where p is the fractional number percentage / PERCENTAGE_FACTOR
         // <= max(x, y) + 2 <= type(uint256).max - HALF_PERCENTAGE_FACTOR + 2 <= type(uint256).max
         assembly {
             z := sub(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -125,8 +125,7 @@ library PercentageMath {
         assembly {
             let sub_ := sub(PERCENTAGE_FACTOR, percentage)
             let x1 := div(add(mul(x, sub_), HALF_PERCENTAGE_FACTOR), PERCENTAGE_FACTOR)
-            let x2 := div(add(mul(y, percentage), HALF_PERCENTAGE_FACTOR), PERCENTAGE_FACTOR)
-            let sum := add(x1, x2)
+            z := add(x1, div(add(mul(y, percentage), HALF_PERCENTAGE_FACTOR), PERCENTAGE_FACTOR))
 
             if or(
                 or(
@@ -136,12 +135,10 @@ library PercentageMath {
                     ),
                     mul(percentage, gt(y, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, percentage)))
                 ),
-                lt(sum, x1)
+                lt(z, x1)
             ) {
                 revert(0, 0)
             }
-
-            z := add(x1, x2)
         }
     }
 }

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -49,7 +49,7 @@ library PercentageMath {
         // percentage > PERCENTAGE_FACTOR
         // or x * (PERCENTAGE_FACTOR - percentage) + HALF_PERCENTAGE_FACTOR > type(uint256).max
         // <=> percentage > PERCENTAGE_FACTOR
-        // or ((PERCENTAGE_FACTOR - percentage) > 0 and x > type(uint256).max - HALF_PERCENTAGE_FACTOR / (PERCENTAGE_FACTOR - percentage))
+        // or ((PERCENTAGE_FACTOR - percentage) > 0 and x > (type(uint256).max - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage))
         assembly {
             y := sub(PERCENTAGE_FACTOR, percentage) // Temporary assignment to save gas.
 

--- a/src/math/PercentageMath.sol
+++ b/src/math/PercentageMath.sol
@@ -27,7 +27,13 @@ library PercentageMath {
         assembly {
             y := add(percentage, PERCENTAGE_FACTOR) // Temporary assīgnement to save gas.
 
-            if mul(y, or(gt(percentage, sub(MAX_UINT256, PERCENTAGE_FACTOR)), gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, y)))) {
+            if mul(
+                y,
+                or(
+                    gt(percentage, sub(MAX_UINT256, PERCENTAGE_FACTOR)),
+                    gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, y))
+                )
+            ) {
                 revert(0, 0)
             }
 
@@ -122,7 +128,16 @@ library PercentageMath {
             let x2 := div(add(mul(y, percentage), HALF_PERCENTAGE_FACTOR), PERCENTAGE_FACTOR)
             let sum := add(x1, x2)
 
-            if or(or(mul(sub_, or(gt(percentage, PERCENTAGE_FACTOR), gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, sub_)))), mul(percentage, gt(y, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, percentage)))), lt(sum, x1)) {
+            if or(
+                or(
+                    mul(
+                        sub_,
+                        or(gt(percentage, PERCENTAGE_FACTOR), gt(x, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, sub_)))
+                    ),
+                    mul(percentage, gt(y, div(MAX_UINT256_MINUS_HALF_PERCENTAGE, percentage)))
+                ),
+                lt(sum, x1)
+            ) {
                 revert(0, 0)
             }
 

--- a/test/TestPercentageMath.sol
+++ b/test/TestPercentageMath.sol
@@ -92,7 +92,7 @@ contract TestPercentageMath is Test {
     function testPercentAddOverflow(uint256 x, uint256 y) public {
         vm.assume(y > MAX_UINT256 - PERCENTAGE_FACTOR);
 
-        vm.expectRevert(stdError.arithmeticError);
+        vm.expectRevert();
         PercentageMath.percentAdd(x, y);
     }
 

--- a/test/TestPercentageMath.sol
+++ b/test/TestPercentageMath.sol
@@ -168,9 +168,8 @@ contract TestPercentageMath is Test {
         uint16 percentage
     ) public {
         vm.assume(percentage <= 1e4);
-        vm.assume(percentage == 1e4 || x <= type(uint256).max / (1e4 - percentage));
         vm.assume(percentage == 0 || y <= (type(uint256).max - 0.5e4) / percentage);
-        vm.assume(x * (1e4 - percentage) <= type(uint256).max - y * percentage - 0.5e4);
+        vm.assume(1e4 - percentage == 0 || x <= (type(uint256).max - y * percentage - 0.5e4) / (1e4 - percentage));
 
         assertEq(PercentageMath.weightedAvg(x, y, percentage), mathRef.weightedAvg(x, y, percentage));
     }
@@ -181,11 +180,9 @@ contract TestPercentageMath is Test {
         uint256 percentage
     ) public {
         vm.assume(percentage <= 1e4);
-        // prettier-ignore
         vm.assume(
-            ( percentage != 1e4 && x > type(uint256).max / (1e4 - percentage) )         || 
-            ( percentage != 0   && y > (type(uint256).max - 0.5e4) / percentage )       ||
-            x * (1e4 - percentage) > type(uint256).max - y * percentage - 0.5e4
+            (percentage != 0 && y > (type(uint256).max - 0.5e4) / percentage) ||
+                ((1e4 - percentage) != 0 && x > (type(uint256).max - y * percentage - 0.5e4) / (1e4 - percentage))
         );
 
         vm.expectRevert();

--- a/test/TestPercentageMath.sol
+++ b/test/TestPercentageMath.sol
@@ -86,10 +86,7 @@ contract TestPercentageMath is Test {
         vm.assume(p <= MAX_UINT256 - PERCENTAGE_FACTOR);
         vm.assume(x <= MAX_UINT256 / (PERCENTAGE_FACTOR + p));
 
-        assertEq(
-            PercentageMath.percentAdd(x, p),
-            (x * (PERCENTAGE_FACTOR + p) + HALF_PERCENTAGE_FACTOR) / PERCENTAGE_FACTOR
-        );
+        assertEq(PercentageMath.percentAdd(x, p), mathRef.percentAdd(x, p));
     }
 
     function testPercentAddOverflow(uint256 x, uint256 p) public {
@@ -113,10 +110,7 @@ contract TestPercentageMath is Test {
         vm.assume(p <= PERCENTAGE_FACTOR);
         vm.assume(x <= MAX_UINT256 / (PERCENTAGE_FACTOR - p));
 
-        assertEq(
-            PercentageMath.percentSub(x, p),
-            (x * (PERCENTAGE_FACTOR - p) + HALF_PERCENTAGE_FACTOR) / PERCENTAGE_FACTOR
-        );
+        assertEq(PercentageMath.percentSub(x, p), mathRef.percentSub(x, p));
     }
 
     function testPercentSubUnderflow(uint256 x, uint256 p) public {
@@ -177,12 +171,7 @@ contract TestPercentageMath is Test {
             (PERCENTAGE_FACTOR - percentage == 0 || x <= MAX_UINT256_MINUS_HALF_PERCENTAGE / (PERCENTAGE_FACTOR - percentage))
         );
 
-        assertEq(
-            PercentageMath.weightedAvg(x, y, percentage),
-            // prettier-ignore
-            ((x * (PERCENTAGE_FACTOR - percentage) + HALF_PERCENTAGE_FACTOR) / PERCENTAGE_FACTOR) +
-            ((y * percentage)                      + HALF_PERCENTAGE_FACTOR) / PERCENTAGE_FACTOR
-        );
+        assertEq(PercentageMath.weightedAvg(x, y, percentage), mathRef.weightedAvg(x, y, percentage));
     }
 
     function testFailWeightedAvgOverflow(

--- a/test/TestPercentageMath.sol
+++ b/test/TestPercentageMath.sol
@@ -126,6 +126,14 @@ contract TestPercentageMath is Test {
         PercentageMath.percentSub(x, p);
     }
 
+    function testPercentSubOverflow(uint256 x, uint256 p) public {
+        vm.assume(p <= PERCENTAGE_FACTOR);
+        vm.assume(x > MAX_UINT256 / (PERCENTAGE_FACTOR - p));
+
+        vm.expectRevert();
+        PercentageMath.percentSub(x, p);
+    }
+
     function testPercentMul(uint256 x, uint256 p) public {
         vm.assume(p == 0 || x <= MAX_UINT256_MINUS_HALF_PERCENTAGE / p);
 

--- a/test/TestPercentageMath.sol
+++ b/test/TestPercentageMath.sol
@@ -174,7 +174,7 @@ contract TestPercentageMath is Test {
         assertEq(PercentageMath.weightedAvg(x, y, percentage), mathRef.weightedAvg(x, y, percentage));
     }
 
-    function testFailWeightedAvgOverflow(
+    function testWeightedAvgOverflow(
         uint256 x,
         uint256 y,
         uint256 percentage
@@ -186,16 +186,18 @@ contract TestPercentageMath is Test {
             (PERCENTAGE_FACTOR - percentage > 0 && x > (MAX_UINT256_MINUS_HALF_PERCENTAGE / (PERCENTAGE_FACTOR - percentage)))
         );
 
+        vm.expectRevert();
         PercentageMath.weightedAvg(x, y, percentage);
     }
 
-    function testFailWeightedAvgUnderflow(
+    function testWeightedAvgUnderflow(
         uint256 x,
         uint256 y,
         uint256 percentage
     ) public {
         vm.assume(percentage > PERCENTAGE_FACTOR);
 
+        vm.expectRevert();
         PercentageMath.weightedAvg(x, y, percentage);
     }
 

--- a/test/TestPercentageMath.sol
+++ b/test/TestPercentageMath.sol
@@ -116,7 +116,7 @@ contract TestPercentageMath is Test {
     function testPercentSubUnderflow(uint256 x, uint256 y) public {
         vm.assume(y > PERCENTAGE_FACTOR);
 
-        vm.expectRevert(stdError.arithmeticError);
+        vm.expectRevert();
         PercentageMath.percentSub(x, y);
     }
 

--- a/test/TestPercentageMath.sol
+++ b/test/TestPercentageMath.sol
@@ -167,9 +167,12 @@ contract TestPercentageMath is Test {
         uint256 y,
         uint16 percentage
     ) public {
-        vm.assume(percentage <= 1e4);
-        vm.assume(percentage == 0 || y <= (type(uint256).max - 0.5e4) / percentage);
-        vm.assume(1e4 - percentage == 0 || x <= (type(uint256).max - y * percentage - 0.5e4) / (1e4 - percentage));
+        vm.assume(percentage <= PERCENTAGE_FACTOR);
+        vm.assume(percentage == 0 || y <= (MAX_UINT256 - HALF_PERCENTAGE_FACTOR) / percentage);
+        vm.assume(
+            PERCENTAGE_FACTOR - percentage == 0 ||
+                x <= (MAX_UINT256 - y * percentage - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage)
+        );
 
         assertEq(PercentageMath.weightedAvg(x, y, percentage), mathRef.weightedAvg(x, y, percentage));
     }
@@ -179,10 +182,11 @@ contract TestPercentageMath is Test {
         uint256 y,
         uint256 percentage
     ) public {
-        vm.assume(percentage <= 1e4);
+        vm.assume(percentage <= PERCENTAGE_FACTOR);
         vm.assume(
-            (percentage != 0 && y > (type(uint256).max - 0.5e4) / percentage) ||
-                ((1e4 - percentage) != 0 && x > (type(uint256).max - y * percentage - 0.5e4) / (1e4 - percentage))
+            (percentage != 0 && y > (MAX_UINT256 - HALF_PERCENTAGE_FACTOR) / percentage) ||
+                ((PERCENTAGE_FACTOR - percentage) != 0 &&
+                    x > (MAX_UINT256 - y * percentage - HALF_PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR - percentage))
         );
 
         vm.expectRevert();


### PR DESCRIPTION
We could improve the average computation if we do the following:
`(x * (1 - percentage) + y * percentage) / PERCENTAGE_FACTOR` instead of:
`x * (1 - percentage)  / PERCENTAGE_FACTOR + y * percentage / PERCENTAGE_FACTOR`

Note that it's not the same computation with the roundings and also it would overflow with a lower (x, y) pair.